### PR TITLE
カードの3点リーダーの修正とtooltip追加

### DIFF
--- a/web/resources/js/components/Cards.vue
+++ b/web/resources/js/components/Cards.vue
@@ -1,32 +1,54 @@
 <template>
-    <v-list class="py-0" width="100%">
-      <v-col class="px-md-0" v-for="card in cards" :key="card" :card="card">
-        <v-card class="rounded" outlined>
-          <v-list class="py-0" style="height: 80px">
-            <v-list-item @click="toHypothesis" style="height: 80px" link>
-              <v-list-item-content>
-                <v-list-item-title
-                  ><p class="font-weight-black ma-0">
-                    {{ card }}
-                  </p></v-list-item-title
+  <v-list class="py-0" width="100%">
+    <v-col class="px-md-0" v-for="card in cards" :key="card" :card="card">
+      <v-card class="rounded" outlined>
+        <v-list class="py-0" style="height: 80px">
+          <v-list-item @click="toHypothesis" style="height: 80px" link>
+            <v-list-item-content>
+              <v-list-item-title
+                ><p class="font-weight-black ma-0">
+                  {{ card }}
+                </p></v-list-item-title
+              >
+            </v-list-item-content>
+
+            <v-menu class="rounded-lg elevation-0" offset-y>
+              <template v-slot:activator="{ on, attrs }">
+                <v-list-item-action
+                  class="ma-0"
+                  style="position: absolute; top: 32px; right: 16px"
                 >
-              </v-list-item-content>
-              <v-icon>mdi-dots-vertical</v-icon>
-            </v-list-item>
-          </v-list>
-        </v-card>
-      </v-col>
-    </v-list>
+                  <v-btn v-bind="attrs" v-on="on" small icon link>
+                    <v-icon>mdi-dots-vertical</v-icon>
+                  </v-btn>
+                </v-list-item-action>
+              </template>
+              <v-list>
+                <v-list-item v-for="menu in cardMenu" :key="menu" link>
+                  <v-list-item-title :style="menu.color">{{
+                    menu.title
+                  }}</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
+          </v-list-item>
+        </v-list>
+      </v-card>
+    </v-col>
+  </v-list>
 </template>
 
 <script>
 export default {
   data: () => ({
     cards: ["VizHD", "開発", "マーケティング", "営業", "CS", "経理", "総務"],
+    cardMenu: [
+      {title: "削除", color:"color: red"},
+    ]
   }),
   methods: {
     toHypothesis: function () {
-      return this.$router.push({ path: '/project/123' }) 
+      return this.$router.push({ path: "/project/123" });
     },
   },
 };

--- a/web/resources/js/components/Cards/HypothesisCard.vue
+++ b/web/resources/js/components/Cards/HypothesisCard.vue
@@ -2,22 +2,51 @@
   <v-list class="py-0" width="100%">
     <v-col class="px-md-0" v-for="card in cards" :key="card" :cards="cards">
       <v-card class="rounded" outlined>
-        <v-list class="py-0" style="height: 80px">
-          <v-list-item style="height: 80px" @click="toHypothesisDetail" link>
-            <v-list-item-content class="pa-0">
-              <v-list-item-subtitle class="d-flex justify-start pt-3 pb-1">
-                <v-icon size="8">circle</v-icon>
-                <p class="ma-0 px-2 grey--text font-weight-bold" style="font-size: 12px">Not yet</p>
-              </v-list-item-subtitle>
-              <div class="d-flex justify-space-between pb-2" style="height: 40px">
-                <v-list-item-title>
+        <v-list class="py-0 d-flex align-content-center" style="height: 80px">
+          <v-list-item @click="toHypothesisDetail" link>
+            <v-list-item-content class="pa-0 d-flex flex-nowrap">
+              <div>
+                <v-list-item-subtitle class="d-flex align-content-start py-3">
+                  <v-icon size="8">circle</v-icon>
+                  <p
+                    class="ma-0 px-2 grey--text font-weight-bold"
+                    style="font-size: 12px"
+                  >
+                    Not yet
+                  </p>
+                </v-list-item-subtitle>
+                <v-list-item-title class="pb-4">
                   <p class="font-weight-black ma-0">
                     {{ card }}
                   </p></v-list-item-title
                 >
-                <v-list-item-action>
-                  <v-icon>mdi-dots-vertical</v-icon>
-                </v-list-item-action>
+                <v-menu class="rounded-lg elevation-0" offset-y>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-list-item-action
+                      class="ma-0"
+                      style="
+                        position: absolute;
+                        top: 32px;
+                        right: 16px;
+                      "
+                    >
+                      <v-btn
+                        v-bind="attrs"
+                        v-on="on"
+                        small
+                        icon
+                        link
+                      >
+                        <v-icon>mdi-dots-vertical</v-icon>
+                      </v-btn>
+                    </v-list-item-action>
+                  </template>
+                  <v-list>
+                    <v-list-item v-for="menu in cardMenu" :key="menu" link>
+                      <v-list-item-title :style="menu.color">{{ menu.title }}</v-list-item-title>
+                    </v-list-item>
+                  </v-list>
+                </v-menu>
               </div>
             </v-list-item-content>
           </v-list-item>
@@ -29,6 +58,13 @@
 
 <script>
 export default {
+  data: () => ({
+    cardMenu: [
+      {title: "ゴールにする", color:""},
+      {title: "今日の目標にする", color: ""},
+      {title: "削除", color:"color: red"},
+    ]
+  }),
   props: {
     cards: {
       type: Array,
@@ -39,7 +75,7 @@ export default {
   },
   methods: {
     toHypothesisDetail: function () {
-      return this.$router.push({ path: '/project/123/123' }) 
+      return this.$router.push({ path: "/project/123/123" });
     },
   },
 };


### PR DESCRIPTION
## URL

*

## todo

* カードの3点リーダーの位置を修正
* 3点リーダーをクリックしたら編集。削除そして仮説カードは今日の目標にするとゴールにするを選択できるように。

## 影響範囲

* 

## テスト

* 

## 参考資料

* 

## 保留したこと

* menuのデザイン

## その他

* 
