### PR TITLE
plusボタン押下後のフォーム表示処理キャンセルの方を実装する

### DIFF
--- a/web/resources/js/pages/HypothesisList.vue
+++ b/web/resources/js/pages/HypothesisList.vue
@@ -111,7 +111,7 @@ export default {
       this.$store.dispatch("form/onClickCreate");
     },  
     onClickCancel() {
-      this.$store.dispatch("form/onClickCancel");
+      this.$store.dispatch("form/closeForm");
     },
     submitForm(){      
       this.$store.dispatch("form/closeForm");


### PR DESCRIPTION
## URL

*

## 背景

* プラスで新規作成を押すときキャンセルした後フォームがfalseされない

## todo

* 原因探す
* そもそもゴールを作った後のonClickCancelが効いてない
* onClickCancelじゃなくてcloseFormでした

## 影響範囲

* 

## テスト

* 

## 参考資料

* 

## 保留したこと

* 

## その他

* 
