### PR TITLE
名前の編集で仮説が空になった時送信させない

### DIFF
--- a/web/resources/js/pages/HypothesisDetail.vue
+++ b/web/resources/js/pages/HypothesisDetail.vue
@@ -32,7 +32,7 @@
               <p class="ma-0 font-weight-bold" color="grey darken-1">{{ subHeader }}</p>
             </v-subheader>
             <v-textarea
-              label="subHeader + 'を入力'"
+              label="名前を入力"
               v-model="hypothesis.name"
               @change="editHypothesisName"
               class="pa-0 text-h5"
@@ -211,11 +211,9 @@ export default {
       }
     },
     editHypothesisName(){
-      console.info(this.hypothesis)
-        if (this.hypothesis.name) {
-          console.info(this.hypothesis.name);
-          this.$store.dispatch("hypothesis/editHypothesis", this.hypothesis);
-        }
+      if (this.hypothesis.name) {
+        this.$store.dispatch("hypothesis/editHypothesis", this.hypothesis);
+      }
     },
   },
 };

--- a/web/resources/js/store/hypothesis.js
+++ b/web/resources/js/store/hypothesis.js
@@ -105,10 +105,6 @@ const mutations = {
         state.allHypothesisList[projectUuid] = state.hypothesisList;
     },
 
-    updateHypothesisName (state, data) {
-        state.hypothesisList[data.uuid]['name'] = data.name;
-    },
-
     updateHypothesisAccomplish (state, accomplish){
         state.hypothesis.accomplish = accomplish;
     },
@@ -215,11 +211,7 @@ const actions = {
     async editHypothesis (context, data) {
         await axios.get ('/sanctum/csrf-cookie', {withCredentials: true});
         const response = await axios.put('/api/hypothesis/'+ data.uuid, data)
-
-        if (response.status === OK) {
-            context.commit('updateHypothesisName', data);
-            return false;
-        } else {
+        if (response.status !== OK) {
             context.commit ('error/setCode', response.status, {root: true});
             return false;
         }


### PR DESCRIPTION
## URL

*

## 背景

* 仮説の名前の編集で仮説の名前が空になった時laravel側に送信されてエラーになる

## todo

* 空の時は送信させない

## 影響範囲

* 仮設詳細ページ

## テスト

* 

## 参考資料

* 

## 保留したこと

* 仮説の名前が空になった時vueのstate側でからのままになって真っ白の状態で仮説カードが表示されること

## その他

* 
