### PR TITLE
戻るボタンを押したらしっかりページが読み込まれる

### DIFF
--- a/web/resources/js/pages/HypothesisDetail.vue
+++ b/web/resources/js/pages/HypothesisDetail.vue
@@ -231,6 +231,14 @@ export default {
       }
     },
   },
+  watch: {
+    $route (to, from) {
+      //ブラウザバックで戻った先が再び仮説詳細ページだった場合
+      if (to.params.id === this.parentHypothesis.uuid) {
+        this.$store.dispatch("hypothesis/selectHypothesis", this.parentHypothesis);
+      }
+    }
+  },
 };
 </script>
 


### PR DESCRIPTION
## URL

*

## 背景

* 戻るを押してもリンクは遷移されてもページが読み込まれない

## todo

* 原因を探す
    * 原因はストアが更新されない
* urlが親仮説と同じだった時のみ親仮説を新しい仮説にセレクトするようにした

## 影響範囲

* 

## テスト

* 

## 参考資料

* 

## 保留したこと

* 

## その他

* 
