### PR TITLE
TodoのフォームリクエストでDateが空の時通らない

### DIFF
--- a/web/app/Http/Requests/TodoRequest.php
+++ b/web/app/Http/Requests/TodoRequest.php
@@ -27,7 +27,7 @@ class TodoRequest extends FormRequest
         return [
             'name'  => 'required|max:64',
             'uuid' => 'required',
-            'date'  => 'date_format:Y-m-d'
+            'date'  => 'nullable|date_format:Y-m-d'
         ];
     }
 


### PR DESCRIPTION
## URL

*

## 背景

* FormRequestでValidationを通すようにしてから日付が空で通過しない

## todo

- [x] TodoのFormRequestにnullableで通るか試す

## 影響範囲

* 

## テスト

* 

## 参考資料

* 

## 保留したこと

* 

## その他

* 
