### PR TITLE
フォーム上で日付を削除するボタンが押せない

### DIFF
--- a/web/resources/js/components/Calender.vue
+++ b/web/resources/js/components/Calender.vue
@@ -21,6 +21,7 @@
             </v-text-field>
             <div
                 class="d-flex align-self-center"
+                style="z-index: 100"
                 :style="
                     todo.name
                         ? 'position: relative; right: 20px'


### PR DESCRIPTION
## URL

*

## 背景

* フォームの日付の×ボタンが後ろに隠れていて押しても反応しない

## todo

- [ ] z-indexをつける

## 影響範囲

* 

## テスト

* 

## 参考資料

* 

## 保留したこと

* 

## その他

* 
