### PR TITLE
ユーザー検索するのをidからuuidに変更します

### DIFF
--- a/web/app/Http/Controllers/AccomplishController.php
+++ b/web/app/Http/Controllers/AccomplishController.php
@@ -21,7 +21,7 @@ class AccomplishController extends Controller
     {
         $todo = [
             'uuid' => $todo_uuid,
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
         ];
 
         $update_action->invoke($todo);
@@ -46,7 +46,7 @@ class AccomplishController extends Controller
     {
         $todo = [
             'uuid' => $todo_uuid,
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
         ];
 
         $destroy_action->invoke($todo);

--- a/web/app/Http/Controllers/Auth/LoginController.php
+++ b/web/app/Http/Controllers/Auth/LoginController.php
@@ -49,7 +49,7 @@ class LoginController extends Controller
 
         if (Auth::attempt($credentials)) {
             $request->session()->regenerate();
-            $onboarding = $this->user_repository->whetherExecuteOnboarding($request->user()->id);
+            $onboarding = $this->user_repository->whetherExecuteOnboarding($request->user()->uuid);
             $user = new UserResource($request->user());
             $response = [
                 'user' => $user,

--- a/web/app/Http/Controllers/Auth/RegisterController.php
+++ b/web/app/Http/Controllers/Auth/RegisterController.php
@@ -41,7 +41,7 @@ class RegisterController extends Controller
         $create_user = $this->user_repository->register($user);
 
         if ($create_user) {
-            $generateAction->invoke($user->id);
+            $generateAction->invoke($user->uuid);
         }
 
         return response()->json(new UserResource($user), Response::HTTP_CREATED);

--- a/web/app/Http/Controllers/CauseController.php
+++ b/web/app/Http/Controllers/CauseController.php
@@ -41,7 +41,7 @@ class CauseController extends Controller
     public function store(string $todo_uuid, CauseRequest $request, StoreAction $store_action)
     {
         $cause = [
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
             'todo_uuid' => $todo_uuid,
             'cause_uuid' => $request->uuid,
             'text' => $request->text
@@ -102,7 +102,7 @@ class CauseController extends Controller
     public function destroy(string $cause_uuid, Request $request, DestroyAction $destroy_action)
     {
         $cause = [
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
             'cause_uuid' => $cause_uuid,
         ];
 

--- a/web/app/Http/Controllers/CommentController.php
+++ b/web/app/Http/Controllers/CommentController.php
@@ -32,7 +32,7 @@ class CommentController extends Controller
     public function store(string $todo_uuid, CommentRequest $request, StoreAction $store_action)
     {
         $comment = [
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
             'todo_uuid' => $todo_uuid,
             'comment_uuid' => $request->uuid,
             'text' => $request->text
@@ -69,7 +69,7 @@ class CommentController extends Controller
     public function update(CommentRequest $request, UpdateAction $update_action)
     {
         $comment = [
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
             'uuid' => $request->uuid,
             'text' => $request->text
         ];
@@ -95,7 +95,7 @@ class CommentController extends Controller
     public function destroy(string $comment_uuid, Request $request, DestroyAction $destroy_action)
     {
         $comment = [
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
             'comment_uuid' => $comment_uuid,
         ];
 

--- a/web/app/Http/Controllers/DateController.php
+++ b/web/app/Http/Controllers/DateController.php
@@ -54,7 +54,7 @@ class DateController extends Controller
         $todo = [
             'uuid' => $todo_uuid,
             'date' => $request->date,
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
         ];
 
         $update_action->invoke($todo);
@@ -79,7 +79,7 @@ class DateController extends Controller
     {
         $todo = [
             'uuid' => $todo_uuid,
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
         ];
 
         $destroy_action->invoke($todo);

--- a/web/app/Http/Controllers/GoalController.php
+++ b/web/app/Http/Controllers/GoalController.php
@@ -32,7 +32,7 @@ class GoalController extends Controller
             'uuid' => $request->uuid,
             'parent_uuid' => $request->parentUuid,
             'date' => $request->date,
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
         ];
 
         $store_action->invoke($goal);

--- a/web/app/Http/Controllers/Initialize.php
+++ b/web/app/Http/Controllers/Initialize.php
@@ -36,10 +36,10 @@ class Initialize extends Controller
         \App\UseCases\Project\IndexAction $project_index_action,
         \App\UseCases\Date\IndexAction $date_index_action,
     ) {
-        $todo_list = $get_user_has_project_and_todo_action->invoke($request->user()->id);
-        $project_list = $project_index_action->invoke($request->user()->id);
-        $schedule_list = $date_index_action->invoke($request->user()->id);
-        $onboarding = $this->user_repository->whetherExecuteOnboarding($request->user()->id);
+        $todo_list = $get_user_has_project_and_todo_action->invoke($request->user()->uuid);
+        $project_list = $project_index_action->invoke($request->user()->uuid);
+        $schedule_list = $date_index_action->invoke($request->user()->uuid);
+        $onboarding = $this->user_repository->whetherExecuteOnboarding($request->user()->uuid);
 
         $user_has_project_and_todo = [
             'project' => $project_list,

--- a/web/app/Http/Controllers/Onboarding.php
+++ b/web/app/Http/Controllers/Onboarding.php
@@ -37,7 +37,7 @@ class Onboarding extends Controller
                 'uuid' => (string) Str::uuid(),
                 'date' => $request->goalDate
             ],
-            'created_by_user_id' => $request->user()->id
+            'created_by_user_uuid' => $request->user()->uuid
         ];
         $this->user_repository->finishedOnboarding($onboarding);
         $json = [

--- a/web/app/Http/Controllers/ProjectController.php
+++ b/web/app/Http/Controllers/ProjectController.php
@@ -22,10 +22,10 @@ class ProjectController extends Controller
      */
     public function index(ProjectRequest $request, IndexAction $index_action)
     {
-        $user_id = $request->user()->id;
+        $user_uuid = $request->user()->uuid;
 
         // ユースケースを実行し、レスポンスの元になるデータを受け取る
-        $project_list = $index_action->invoke($user_id);
+        $project_list = $index_action->invoke($user_uuid);
 
         return response()->json($project_list, Response::HTTP_OK);
     }
@@ -43,7 +43,7 @@ class ProjectController extends Controller
         $project = [
             'name' => $request->name,
             'uuid' => (string) Str::uuid(),
-            'created_by_user_id' => $request->user()->id,
+            'created_by_user_uuid' => $request->user()->uuid,
         ];
 
         // ユースケースを実行し、レスポンスの元になるデータを受け取る
@@ -82,7 +82,7 @@ class ProjectController extends Controller
         $project = [
             'name' => $request->name,
             'uuid' => $request->uuid,
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
         ];
 
         $update_action->invoke($project);
@@ -108,7 +108,7 @@ class ProjectController extends Controller
     {
         $project = [
             'uuid' => $project_uuid,
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
         ];
 
         $destroy_action->invoke($project);

--- a/web/app/Http/Controllers/TodoController.php
+++ b/web/app/Http/Controllers/TodoController.php
@@ -35,7 +35,7 @@ class TodoController extends Controller
             'uuid' => $request->uuid,
             'parent_uuid' => $request->parentUuid,
             'date' => $request->date,
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
         ];
 
         $store_action->invoke($todo);
@@ -71,7 +71,7 @@ class TodoController extends Controller
         $todo = [
             'name' => $request->name,
             'uuid' => $request->uuid,
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
         ];
 
         $update_action->invoke($todo);
@@ -96,7 +96,7 @@ class TodoController extends Controller
     {
         $todo = [
             'uuid' => $todoUuid,
-            'user_id' => $request->user()->id,
+            'user_uuid' => $request->user()->uuid,
         ];
 
         $destroy_action->invoke($todo);

--- a/web/app/Repositories/Cause/CauseRepository.php
+++ b/web/app/Repositories/Cause/CauseRepository.php
@@ -23,7 +23,7 @@ class CauseRepository implements CauseRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id }) - [:CREATED] -> (todo:Todo {uuid: $todo_uuid})
+                MATCH (user:User { uuid : $user_uuid }) - [:CREATED] -> (todo:Todo {uuid: $todo_uuid})
                 CREATE (cause:Cause{
                     uuid: $cause_uuid,
                     text: $text
@@ -34,7 +34,7 @@ class CauseRepository implements CauseRepositoryInterface
                 RETURN user, todo, cause
                 CYPHER,
             [
-                'user_id' => $cause['user_id'],
+                'user_uuid' => $cause['user_uuid'],
                 'todo_uuid' => $cause['todo_uuid'],
                 'cause_uuid' => $cause['cause_uuid'],
                 'text' => $cause['text']
@@ -51,14 +51,14 @@ class CauseRepository implements CauseRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id }) - [created:CREATED] -> (cause:Cause { uuid : $cause_uuid }),
+                MATCH (user:User { uuid : $user_uuid }) - [created:CREATED] -> (cause:Cause { uuid : $cause_uuid }),
                 (cause) <- [is_the_cause_of:IS_THE_CAUSE_OF] - (todo:Todo)
                 DELETE is_the_cause_of, created
                 DELETE cause
                 RETURN user
                 CYPHER,
             [
-                'user_id' => $cause['user_id'],
+                'user_uuid' => $cause['user_uuid'],
                 'cause_uuid' => $cause['cause_uuid']
             ]
         );

--- a/web/app/Repositories/Comment/CommentRepository.php
+++ b/web/app/Repositories/Comment/CommentRepository.php
@@ -23,7 +23,7 @@ class CommentRepository implements CommentRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id }) - [:CREATED] -> (todo:Todo {uuid: $todo_uuid})
+                MATCH (user:User { uuid : $user_uuid }) - [:CREATED] -> (todo:Todo {uuid: $todo_uuid})
                 CREATE (comment:Comment{
                     uuid: $comment_uuid,
                     text: $text
@@ -34,7 +34,7 @@ class CommentRepository implements CommentRepositoryInterface
                 RETURN user, todo, comment
                 CYPHER,
             [
-                'user_id' => $comment['user_id'],
+                'user_uuid' => $comment['user_uuid'],
                 'todo_uuid' => $comment['todo_uuid'],
                 'comment_uuid' => $comment['comment_uuid'],
                 'text' => $comment['text']
@@ -51,7 +51,7 @@ class CommentRepository implements CommentRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id }), (comment:Comment { uuid: $uuid })
+                MATCH (user:User { uuid : $user_uuid }), (comment:Comment { uuid: $uuid })
                 SET comment.text = $text
                 WITH user,comment
                 OPTIONAL MATCH x = (user)-[updated:UPDATED]->(comment)
@@ -63,7 +63,7 @@ class CommentRepository implements CommentRepositoryInterface
                 RETURN comment
                 CYPHER,
             [
-                'user_id' => $comment['user_id'],
+                'user_uuid' => $comment['user_uuid'],
                 'uuid' => $comment['uuid'],
                 'text' => $comment['text']
             ]
@@ -79,14 +79,14 @@ class CommentRepository implements CommentRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id }) - [created:CREATED] -> (comment:Comment { uuid : $comment_uuid }),
+                MATCH (user:User { uuid : $user_uuid }) - [created:CREATED] -> (comment:Comment { uuid : $comment_uuid }),
                 (comment) - [to: TO] -> (todo:Todo)
                 DELETE to, created
                 DELETE comment
                 RETURN user
                 CYPHER,
             [
-                'user_id' => $comment['user_id'],
+                'user_uuid' => $comment['user_uuid'],
                 'comment_uuid' => $comment['comment_uuid']
             ]
         );

--- a/web/app/Repositories/Date/DateRepository.php
+++ b/web/app/Repositories/Date/DateRepository.php
@@ -17,14 +17,14 @@ class DateRepository implements DateRepositoryInterface
     /**
      * 日付が設定してあるTodoをDBから取得
      *
-     * @param int $user_id
+     * @param string $user_uuid
      * @return $todo_and_schedule
      */
-    public function getDate(int $user_id)
+    public function getDate(string $user_uuid)
     {
         $todo_and_schedule = $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id }) - [date:DATE] -> (todo:Todo),
+                MATCH (user:User { uuid : $user_uuid }) - [date:DATE] -> (todo:Todo),
                 len = (project:Project) <- [r*] - (todo)
                 OPTIONAL MATCH (user) - [accomplished:ACCOMPLISHED] -> (todo)
                 OPTIONAL MATCH (todo) - [:TO_ACHIEVE] -> (parent:Todo)
@@ -36,7 +36,7 @@ class DateRepository implements DateRepositoryInterface
                 ORDER BY date.on ASC
                 CYPHER,
             [
-                'user_id' => $user_id,
+                'user_uuid' => $user_uuid,
             ]
         );
         return $todo_and_schedule;
@@ -51,7 +51,7 @@ class DateRepository implements DateRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id }), (todo:Todo { uuid: $uuid })
+                MATCH (user:User { uuid : $user_uuid }), (todo:Todo { uuid: $uuid })
                 OPTIONAL MATCH x = (user) - [date:DATE] -> (todo)
                 WHERE x IS NOT NULL
                 SET date.on = $date
@@ -64,7 +64,7 @@ class DateRepository implements DateRepositoryInterface
                 CYPHER,
             [
                 'uuid' => $todo['uuid'],
-                'user_id' => $todo['user_id'],
+                'user_uuid' => $todo['user_uuid'],
                 'date' => $todo['date']
             ]
         );
@@ -79,7 +79,7 @@ class DateRepository implements DateRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id }) -
+                MATCH (user:User { uuid : $user_uuid }) -
                 [date: DATE]
                 ->(todo:Todo { uuid: $uuid })
                 DELETE date
@@ -87,7 +87,7 @@ class DateRepository implements DateRepositoryInterface
                 CYPHER,
             [
                 'uuid' => $todo['uuid'],
-                'user_id' => $todo['user_id']
+                'user_uuid' => $todo['user_uuid']
             ]
         );
     }

--- a/web/app/Repositories/Date/DateRepositoryInterface.php
+++ b/web/app/Repositories/Date/DateRepositoryInterface.php
@@ -4,7 +4,7 @@ namespace App\Repositories\Date;
 
 interface DateRepositoryInterface
 {
-    public function getDate(int $user_id);
+    public function getDate(string $user_uuid);
     public function updateDate(array $todo);
     public function destroyDate(array $todo);
 }

--- a/web/app/Repositories/Goal/GoalRepository.php
+++ b/web/app/Repositories/Goal/GoalRepository.php
@@ -23,7 +23,7 @@ class GoalRepository implements GoalRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id }), (project:Project { uuid: $parent_uuid })
+                MATCH (user:User { uuid : $user_uuid }), (project:Project { uuid: $parent_uuid })
                 CREATE (user)-[
                             :CREATED{at:localdatetime({timezone: 'Asia/Tokyo'})}
                         ]->(
@@ -41,7 +41,7 @@ class GoalRepository implements GoalRepositoryInterface
                 'name' => $goal['name'],
                 'uuid' => $goal['uuid'],
                 'parent_uuid' => $goal['parent_uuid'],
-                'user_id' => $goal['user_id'],
+                'user_uuid' => $goal['user_uuid'],
             ]
         );
     }

--- a/web/app/Repositories/Project/ProjectRepository.php
+++ b/web/app/Repositories/Project/ProjectRepository.php
@@ -47,7 +47,7 @@ class ProjectRepository implements ProjectRepositoryInterface
     {
         $created_project = $this->client->run(
             <<<'CYPHER'
-                    MATCH (user:User { user_uuid : $user_uuid })
+                    MATCH (user:User { uuid : $user_uuid })
                     CREATE (user)-[
                                 :HAS{at:localdatetime({timezone: 'Asia/Tokyo'})}
                             ]->(
@@ -76,7 +76,7 @@ class ProjectRepository implements ProjectRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                    MATCH (user:User { user_uuid : $user_uuid }), (project:Project { uuid: $uuid })
+                    MATCH (user:User { uuid : $user_uuid }), (project:Project { uuid: $uuid })
                     SET project.name = $name
                     WITH user,project
                     OPTIONAL MATCH x = (user)-[updated:UPDATED]->(project)
@@ -104,7 +104,7 @@ class ProjectRepository implements ProjectRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_uuid : $user_uuid }), (:User)-[has:HAS]->(project:Project{ uuid :$uuid })
+                MATCH (user:User { uuid : $user_uuid }), (:User)-[has:HAS]->(project:Project{ uuid :$uuid })
                 CREATE (user)-[
                             :DELETED{at:localdatetime({timezone: 'Asia/Tokyo'})}
                         ]->(project)
@@ -129,7 +129,7 @@ class ProjectRepository implements ProjectRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                    MATCH (user:User{user_uuid:$user_uuid})
+                    MATCH (user:User{ uuid : $user_uuid })
                     CREATE (user) - [:HAS{at:localdatetime({timezone: 'Asia/Tokyo'})}] -> (:Project{name:'仕事', uuid:$project_work_uuid})
                     CREATE (user) - [:HAS{at:localdatetime({timezone: 'Asia/Tokyo'})}] -> (:Project{name:'生活', uuid:$project_life_uuid})
                 CYPHER,

--- a/web/app/Repositories/Project/ProjectRepository.php
+++ b/web/app/Repositories/Project/ProjectRepository.php
@@ -18,19 +18,19 @@ class ProjectRepository implements ProjectRepositoryInterface
     /**
      * プロジェクト一覧をDBから取得
      *
-     * @param int $user_id
+     * @param string $user_uuid
      * @return $project_list
      */
-    public function getProjectList(int $user_id)
+    public function getProjectList(string $user_uuid)
     {
         $project_list = $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id })-[:HAS]->(project:Project)
+                MATCH (user:User { uuid : $user_uuid })-[:HAS]->(project:Project)
                 RETURN project
                 ORDER BY project
                 CYPHER,
             [
-                'user_id' => $user_id,
+                'user_uuid' => $user_uuid,
             ]
         );
 
@@ -47,7 +47,7 @@ class ProjectRepository implements ProjectRepositoryInterface
     {
         $created_project = $this->client->run(
             <<<'CYPHER'
-                    MATCH (user:User { user_id : $user_id })
+                    MATCH (user:User { user_uuid : $user_uuid })
                     CREATE (user)-[
                                 :HAS{at:localdatetime({timezone: 'Asia/Tokyo'})}
                             ]->(
@@ -60,7 +60,7 @@ class ProjectRepository implements ProjectRepositoryInterface
             [
                 'name' => $project['name'],
                 'uuid' => $project['uuid'],
-                'user_id' => $project['created_by_user_id'],
+                'user_uuid' => $project['created_by_user_uuid'],
             ]
         );
 
@@ -76,7 +76,7 @@ class ProjectRepository implements ProjectRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                    MATCH (user:User { user_id : $user_id }), (project:Project { uuid: $uuid })
+                    MATCH (user:User { user_uuid : $user_uuid }), (project:Project { uuid: $uuid })
                     SET project.name = $name
                     WITH user,project
                     OPTIONAL MATCH x = (user)-[updated:UPDATED]->(project)
@@ -90,7 +90,7 @@ class ProjectRepository implements ProjectRepositoryInterface
             [
                 'name' => $project['name'],
                 'uuid' => $project['uuid'],
-                'user_id' => $project['user_id'],
+                'user_uuid' => $project['user_uuid'],
             ]
         );
     }
@@ -104,7 +104,7 @@ class ProjectRepository implements ProjectRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id }), (:User)-[has:HAS]->(project:Project{ uuid :$uuid })
+                MATCH (user:User { user_uuid : $user_uuid }), (:User)-[has:HAS]->(project:Project{ uuid :$uuid })
                 CREATE (user)-[
                             :DELETED{at:localdatetime({timezone: 'Asia/Tokyo'})}
                         ]->(project)
@@ -113,7 +113,7 @@ class ProjectRepository implements ProjectRepositoryInterface
                 CYPHER,
             [
                 'uuid' => $project['uuid'],
-                'user_id' => $project['user_id'],
+                'user_uuid' => $project['user_uuid'],
             ]
         );
     }
@@ -123,18 +123,18 @@ class ProjectRepository implements ProjectRepositoryInterface
      * ※絶対にこんな書き方して言い訳がない
      * 会員登録後の使い方のテンプレをKagaction内で表示する
      *
-     * @param string $user_id
+     * @param string $user_uuid
      */
-    public function generateInitialTemplate(int $user_id)
+    public function generateInitialTemplate(string $user_uuid)
     {
         $this->client->run(
             <<<'CYPHER'
-                    MATCH (user:User{user_id:$user_id})
+                    MATCH (user:User{user_uuid:$user_uuid})
                     CREATE (user) - [:HAS{at:localdatetime({timezone: 'Asia/Tokyo'})}] -> (:Project{name:'仕事', uuid:$project_work_uuid})
                     CREATE (user) - [:HAS{at:localdatetime({timezone: 'Asia/Tokyo'})}] -> (:Project{name:'生活', uuid:$project_life_uuid})
                 CYPHER,
             [
-                'user_id' => $user_id,
+                'user_uuid' => $user_uuid,
                 'project_work_uuid' => (string) Str::uuid(),
                 'project_life_uuid' => (string) Str::uuid(),
             ]

--- a/web/app/Repositories/Project/ProjectRepositoryInterface.php
+++ b/web/app/Repositories/Project/ProjectRepositoryInterface.php
@@ -4,9 +4,9 @@ namespace App\Repositories\Project;
 
 interface ProjectRepositoryInterface
 {
-    public function getProjectList(int $user_id);
+    public function getProjectList(string $user_uuid);
     public function create(array $project);
     public function update(array $project);
     public function destroy(array $project);
-    public function generateInitialTemplate(int $user_id);
+    public function generateInitialTemplate(string $user_uuid);
 }

--- a/web/app/Repositories/Todo/TodoRepository.php
+++ b/web/app/Repositories/Todo/TodoRepository.php
@@ -46,7 +46,7 @@ class TodoRepository implements TodoRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH   (user:User { user_id : $user_id }),
+                MATCH   (user:User { uuid : $user_uuid }),
                         (parent:Todo { uuid: $parent_uuid }) - [*] -> (project:Project)
                 CREATE (user)-[
                             :CREATED{at:localdatetime({timezone: 'Asia/Tokyo'})}
@@ -68,7 +68,7 @@ class TodoRepository implements TodoRepositoryInterface
                 'name' => $todo['name'],
                 'uuid' => $todo['uuid'],
                 'parent_uuid' => $todo['parent_uuid'],
-                'user_id' => $todo['user_id'],
+                'user_uuid' => $todo['user_uuid'],
             ]
         );
     }
@@ -82,7 +82,7 @@ class TodoRepository implements TodoRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                    MATCH (user:User { user_id : $user_id }), (todo:Todo { uuid: $uuid })
+                    MATCH (user:User { uuid : $user_uuid }), (todo:Todo { uuid: $uuid })
                     SET todo.name = $name
                     WITH user,todo
                     OPTIONAL MATCH x = (user)-[updated:UPDATED]->(todo)
@@ -96,7 +96,7 @@ class TodoRepository implements TodoRepositoryInterface
             [
                 'name' => $todo['name'],
                 'uuid' => $todo['uuid'],
-                'user_id' => $todo['user_id'],
+                'user_uuid' => $todo['user_uuid'],
             ]
         );
     }
@@ -110,7 +110,7 @@ class TodoRepository implements TodoRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id }), (todo:Todo{ uuid :$uuid }) - [r] -> (parent)
+                MATCH (user:User { uuid : $user_uuid }), (todo:Todo{ uuid :$uuid }) - [r] -> (parent)
                 CREATE (user)-[
                             :DELETED{at:localdatetime({timezone: 'Asia/Tokyo'})}
                         ]->(todo)
@@ -119,7 +119,7 @@ class TodoRepository implements TodoRepositoryInterface
                 CYPHER,
             [
                 'uuid' => $todo['uuid'],
-                'user_id' => $todo['user_id'],
+                'user_uuid' => $todo['user_uuid'],
             ]
         );
     }
@@ -133,7 +133,7 @@ class TodoRepository implements TodoRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id }), (todo:Todo { uuid: $uuid })
+                MATCH (user:User { uuid : $user_uuid }), (todo:Todo { uuid: $uuid })
                 CREATE (user) - [
                     accomplished:ACCOMPLISHED{at:localdatetime({timezone: 'Asia/Tokyo'})}
                 ] -> (todo)
@@ -141,7 +141,7 @@ class TodoRepository implements TodoRepositoryInterface
                 CYPHER,
             [
                 'uuid' => $todo['uuid'],
-                'user_id' => $todo['user_id'],
+                'user_uuid' => $todo['user_uuid'],
             ]
         );
     }
@@ -155,13 +155,13 @@ class TodoRepository implements TodoRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User { user_id : $user_id })-[accomplish:ACCOMPLISHED]->(todo:Todo { uuid: $uuid })
+                MATCH (user:User { uuid : $user_uuid })-[accomplish:ACCOMPLISHED]->(todo:Todo { uuid: $uuid })
                 DELETE accomplish
                 RETURN todo
                 CYPHER,
             [
                 'uuid' => $todo['uuid'],
-                'user_id' => $todo['user_id'],
+                'user_uuid' => $todo['user_uuid'],
             ]
         );
     }

--- a/web/app/Repositories/User/UserRepository.php
+++ b/web/app/Repositories/User/UserRepository.php
@@ -51,18 +51,18 @@ class UserRepository implements UserRepositoryInterface
     /**
      * すでにオンボーディングを終えているかDB上で確認
      *
-     * @param string $user_id
+     * @param string $user_uuid
      * @return $onboarding_done_in_array オンボーディングモデルを配列上にしたもの
      */
-    public function whetherExecuteOnboarding(int $user_id)
+    public function whetherExecuteOnboarding(string $user_uuid)
     {
         $onboarding = $this->client->run(
             <<<'CYPHER'
-                OPTIONAL MATCH (user:User{user_id:$user_id}) - [:NOT_EXECUTE] -> (onboarding:Onboarding)
+                OPTIONAL MATCH ( user:User{ uuid : $user_uuid }) - [:NOT_EXECUTE] -> (onboarding:Onboarding)
                 RETURN onboarding
                 CYPHER,
             [
-                'user_id' => $user_id,
+                'user_uuid' => $user_uuid,
             ]
         );
         $onboarding_done_in_array = $onboarding->toArray()[0]['onboarding'];
@@ -78,7 +78,7 @@ class UserRepository implements UserRepositoryInterface
     {
         $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User{user_id:$user_id}) - [not_execute:NOT_EXECUTE] -> (:Onboarding)
+                MATCH (user:User{ uuid : $user_uuid }) - [not_execute:NOT_EXECUTE] -> (:Onboarding)
                 CREATE (user)-[
                     :HAS{at:localdatetime({timezone: 'Asia/Tokyo'})}
                 ]->(
@@ -107,7 +107,7 @@ class UserRepository implements UserRepositoryInterface
                 'goal_name' => $onboarding['goal']['name'],
                 'goal_uuid' => $onboarding['goal']['uuid'],
                 'goal_date' => $onboarding['goal']['date'],
-                'user_id' => $onboarding['created_by_user_id']
+                'user_uuid' => $onboarding['created_by_user_uuid']
             ]
         );
     }
@@ -115,14 +115,14 @@ class UserRepository implements UserRepositoryInterface
     /**
      * ユーザーが持っているプロジェクトとTodoを取得
      *
-     * @param int $user_id
+     * @param string $user_uuid
      * @return $user_has_project_and_todo
      */
-    public function getUserHasProjetAndTodo(int $user_id)
+    public function getUserHasProjetAndTodo(string $user_uuid)
     {
         $user_has_project_and_todo = $this->client->run(
             <<<'CYPHER'
-                MATCH (user:User{user_id:$user_id}) - [:HAS] -> (project:Project),
+                MATCH (user:User{ uuid : $user_uuid }) - [:HAS] -> (project:Project),
                     len = (project) <- [r*] - (parent:Todo)
                 OPTIONAL MATCH (parent)<-[]-(child:Todo)
                 OPTIONAL MATCH (:User)-[date:DATE]->(parent)
@@ -135,7 +135,7 @@ class UserRepository implements UserRepositoryInterface
                 ORDER BY r
                 CYPHER,
             [
-                'user_id' => $user_id,
+                'user_uuid' => $user_uuid,
             ]
         );
 

--- a/web/app/Repositories/User/UserRepositoryInterface.php
+++ b/web/app/Repositories/User/UserRepositoryInterface.php
@@ -5,7 +5,7 @@ namespace App\Repositories\User;
 interface UserRepositoryInterface
 {
     public function register(object $user);
-    public function whetherExecuteOnboarding(int $user_id);
+    public function whetherExecuteOnboarding(string $user_id);
     public function finishedOnboarding(array $onboarding);
-    public function getUserHasProjetAndTodo(int $user_id);
+    public function getUserHasProjetAndTodo(string $user_id);
 }

--- a/web/app/Repositories/User/UserRepositoryInterface.php
+++ b/web/app/Repositories/User/UserRepositoryInterface.php
@@ -5,7 +5,7 @@ namespace App\Repositories\User;
 interface UserRepositoryInterface
 {
     public function register(object $user);
-    public function whetherExecuteOnboarding(string $user_id);
+    public function whetherExecuteOnboarding(string $user_uuid);
     public function finishedOnboarding(array $onboarding);
-    public function getUserHasProjetAndTodo(string $user_id);
+    public function getUserHasProjetAndTodo(string $user_uuid);
 }

--- a/web/app/UseCases/Date/IndexAction.php
+++ b/web/app/UseCases/Date/IndexAction.php
@@ -23,12 +23,12 @@ class IndexAction
     /**
      * 日付が付随しているTodoを取得して日付があるTodo一覧に展開する
      *
-     * @param int $user_id
+     * @param string $user_uuid
      * @return array $schedule_list 日付があるTodo一覧
      */
-    public function invoke(int $user_id)
+    public function invoke(string $user_uuid)
     {
-        $fetch_todo_and_date = $this->date_repository->getDate($user_id);
+        $fetch_todo_and_date = $this->date_repository->getDate($user_uuid);
         $schedule_list = $this->schedule_list_converter->invoke($fetch_todo_and_date);
         return $schedule_list;
     }

--- a/web/app/UseCases/Initialize/GetUserHasProjectAndTodoAction.php
+++ b/web/app/UseCases/Initialize/GetUserHasProjectAndTodoAction.php
@@ -24,12 +24,12 @@ class GetUserHasProjectAndTodoAction
      * ユーザーのプロジェクトとTodoをDBからfetch
      * Todo一覧に形を変換
      *
-     * @param string $user_id
+     * @param string $user_uuid
      * @return array $todo_list
      */
-    public function invoke(string $user_id)
+    public function invoke(string $user_uuid)
     {
-        $fetch_project_and_todo_from_db = $this->user_repository->getUserHasProjetAndTodo($user_id);
+        $fetch_project_and_todo_from_db = $this->user_repository->getUserHasProjetAndTodo($user_uuid);
         $todo_list = $this->todo_list_converter->invoke($fetch_project_and_todo_from_db);
         return $todo_list;
     }

--- a/web/app/UseCases/Initialize/Template/GenerateAction.php
+++ b/web/app/UseCases/Initialize/Template/GenerateAction.php
@@ -19,10 +19,10 @@ class GenerateAction
     /**
      * テンプレートのプロジェクトをRepository介してDBに保存
      *
-     * @param int $user_id
+     * @param string $user_uuid
      */
-    public function invoke(int $user_id)
+    public function invoke(string $user_uuid)
     {
-        $this->project_repository->generateInitialTemplate($user_id);
+        $this->project_repository->generateInitialTemplate($user_uuid);
     }
 }

--- a/web/app/UseCases/Project/IndexAction.php
+++ b/web/app/UseCases/Project/IndexAction.php
@@ -20,12 +20,12 @@ class IndexAction
      * ユーザーが保持しているプロジェクトをDBから取得
      * 配列化して、uuidをKEYに連想配列で一覧を作る
      *
-     * @param int $user_id
+     * @param string $user_uuid
      * @return array $project_list
      */
-    public function invoke(int $user_id)
+    public function invoke(string $user_uuid)
     {
-        $project_cypher_map = $this->project_repository->getProjectList($user_id);
+        $project_cypher_map = $this->project_repository->getProjectList($user_uuid);
 
         $projcets_cypher_list = $project_cypher_map->toArray();
         $project_list = [];


### PR DESCRIPTION
## URL

*

## 背景

* idだとneo4jとsqlite(pgsql)が被って別ユーザーで二重になる可能性がある
* それだったらuuidの方がリスクは低いので
* uuidにする

## todo

- [ ] idで照合からuuidで照合へ

## 影響範囲

* 

## テスト

* 

## 参考資料

* 

## 保留したこと

* 

## その他

* 
