### PR TITLE
LINEBotのオンボーディング(日付編)

### DIFF
--- a/web/app/Http/Controllers/Api/LineBotController.php
+++ b/web/app/Http/Controllers/Api/LineBotController.php
@@ -69,7 +69,9 @@ class LineBotController extends Controller
         foreach ($events as $event) {
             if ($event->getType() === 'follow') {
                 $follow_action->invoke($event->getUserId());
-            } else if ($event->getType() === 'message') {
+            } else if (
+                $event->getType() === 'message' || $event->getType() === 'postback'
+            ) {
                 $message_received_action->invoke($event);
             }
         }

--- a/web/app/Models/Todo.php
+++ b/web/app/Models/Todo.php
@@ -2,13 +2,13 @@
 
 namespace App\Models;
 
+use DateTime;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use LINE\LINEBot\MessageBuilder\TemplateBuilder\ButtonTemplateBuilder;
 use LINE\LINEBot\TemplateActionBuilder\DatetimePickerTemplateActionBuilder;
 use LINE\LINEBot\MessageBuilder\TextMessageBuilder;
 use LINE\LINEBot\MessageBuilder\TemplateMessageBuilder;
-use Illuminate\Support\Facades\Log;
 
 use function Psy\debug;
 
@@ -55,5 +55,36 @@ class Todo extends Model
             )
         );
         return $builder;
+    }
+
+    /**
+     * 日付を確認する
+     *
+     * @param DateTime $date
+     * @return string $reply_message
+     */
+    public static function confirmDate(DateTime $date)
+    {
+        return  '「' . $date->format('Y年m月d日') . '」だね！';
+    }
+
+    /**
+     * Todo追加の呼びかけ
+     *
+     * @return string $reply_message
+     */
+    public static function callForAdditionalTodo()
+    {
+        return  'ゴールを達成するためにやることをどんどん追加していきましょう！' . "\n" . '「メニュー>やること」からゴール達成のためのやることを追加していくことができます！';
+    }
+
+    /**
+     * 振り返りの設定の説明
+     *
+     * @return string $reply_message
+     */
+    public static function explainSettingOfCheck()
+    {
+        return  'また週に1回、もくサポくんから振り返りのリマインドを送ることができるよ！' . "\n" . '「メニュー>振り返り」から日時の設定を自分で変更することができます！';
     }
 }

--- a/web/app/UseCases/Line/MessageReceivedAction.php
+++ b/web/app/UseCases/Line/MessageReceivedAction.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Log;
 use LINE\LINEBot\HTTPClient\CurlHTTPClient;
 use LINE\LINEBot;
+use DateTime;
 
 
 class MessageReceivedAction
@@ -155,6 +156,12 @@ class MessageReceivedAction
             ];
             Log::debug($date);
             $this->date_repository->updateDate($date);
+            $this->bot->replyText(
+                $event->getReplyToken(),
+                Todo::confirmDate(new DateTime($date['date'])),
+                Todo::callForAdditionalTodo(),
+                Todo::explainSettingOfCheck()
+            );
         }
         return;
     }

--- a/web/app/UseCases/Line/MessageReceivedAction.php
+++ b/web/app/UseCases/Line/MessageReceivedAction.php
@@ -154,14 +154,21 @@ class MessageReceivedAction
                 'user_uuid' => $line_user->uuid,
                 'date' => $event->getPostbackParams()['date']
             ];
-            Log::debug($date);
-            $this->date_repository->updateDate($date);
+
             $this->bot->replyText(
                 $event->getReplyToken(),
                 Todo::confirmDate(new DateTime($date['date'])),
                 Todo::callForAdditionalTodo(),
                 Todo::explainSettingOfCheck()
             );
+
+            //質問の更新
+            $line_user->question->update([
+                'question_number' => LineUsersQuestion::NO_QUESTION,
+                'parent_uuid' => null
+            ]);
+
+            $this->date_repository->updateDate($date);
         }
         return;
     }

--- a/web/app/UseCases/Line/MessageReceivedAction.php
+++ b/web/app/UseCases/Line/MessageReceivedAction.php
@@ -51,6 +51,11 @@ class MessageReceivedAction
     protected $todo_repository;
 
     /**
+     * @param App\Repositories\Todo\DateRepositoryInterface
+     */
+    protected $date_repository;
+
+    /**
      * @param App\Repositories\Line\LineRepositoryInterface $line_repository_interface
      * @param App\Repositories\Project\ProjectRepositoryInterface $project_repository_interface
      * @param App\Repositories\Goal\GoalRepositoryInterface $todo_repository_interface
@@ -61,7 +66,8 @@ class MessageReceivedAction
         LineBotRepositoryInterface $line_bot_repository_interface,
         ProjectRepositoryInterface $project_repository_interface,
         GoalRepositoryInterface $goal_repository_interface,
-        TodoRepositoryInterface $todo_repository_interface
+        TodoRepositoryInterface $todo_repository_interface,
+        DateRepositoryInterface $date_repository_interface,
     ) {
         $this->httpClient = new CurlHTTPClient(config('app.line_channel_access_token'));
         $this->bot = new LINEBot($this->httpClient, ['channelSecret' => config('app.line_channel_secret')]);
@@ -69,6 +75,7 @@ class MessageReceivedAction
         $this->project_repository = $project_repository_interface;
         $this->goal_repository = $goal_repository_interface;
         $this->todo_repository = $todo_repository_interface;
+        $this->date_repository = $date_repository_interface;
     }
 
     /**
@@ -147,6 +154,7 @@ class MessageReceivedAction
                 'date' => $event->getPostbackParams()['date']
             ];
             Log::debug($date);
+            $this->date_repository->updateDate($date);
         }
         return;
     }

--- a/web/app/UseCases/Line/MessageReceivedAction.php
+++ b/web/app/UseCases/Line/MessageReceivedAction.php
@@ -124,7 +124,7 @@ class MessageReceivedAction
             ];
 
             // 返信メッセージ(日付)
-            $response = $this->bot->replyMessage(
+            $this->bot->replyMessage(
                 $event->getReplyToken(),
                 Todo::askTodoLimited($line_user->name, $todo['name'])
             );


### PR DESCRIPTION
## URL

*

## 背景

* 現在LINE Botで振り返りができるよう作成中
* 最初にプロジェクト、ゴール、日付を自然に設定できるようなオンボーディングを行う
* このPRでは日付を受け取ってその後の返答まで行えるようにする

## todo

- [x] 日付を受け取ってneo4jに保存
- [x] 日付を受け取ってから返信を行う

## 影響範囲

* 

## テスト

* 

## 参考資料

* 

## 保留したこと

* sqlのDBにTodoやProjectを保存させてそこから引っ張ってきて返信するということ

## その他

* 
