### PR TITLE
LINE BOT 一覧を見るでもっと見るのカルーセル追加

### DIFF
--- a/web/app/Models/CheckedTodo.php
+++ b/web/app/Models/CheckedTodo.php
@@ -53,9 +53,9 @@ class CheckedTodo extends Model
                     '選択してください', // text
                     null, // 画像url
                     [
-                        new PostbackTemplateActionBuilder('今日までにやること', 'action=CHECK_TODO_BY_TODAY&project_uuid='),
-                        new PostbackTemplateActionBuilder('今週までにやること', 'action=CHECK_TODO_BY_THIS_WEEK&todo_uuid='),
-                        new PostbackTemplateActionBuilder('やること一覧から選択', 'action=SELECT_TODO_LIST_TO_CHECK&todo_uuid='),
+                        new PostbackTemplateActionBuilder('今日までにやること', 'action=CHECK_TODO_BY_TODAY&page=1'),
+                        new PostbackTemplateActionBuilder('今週までにやること', 'action=CHECK_TODO_BY_THIS_WEEK&page=1'),
+                        new PostbackTemplateActionBuilder('やること一覧から選択', 'action=SELECT_TODO_LIST_TO_CHECK&page=1'),
                     ]
                 )
             );

--- a/web/app/Models/Todo.php
+++ b/web/app/Models/Todo.php
@@ -805,7 +805,7 @@ class Todo extends Model
      */
     public static function createViewMoreBubbleContainer(int $todo_carousel_limit, int $current_page, int $count_todo_list, $action_value)
     {
-        $last_page = ceil($count_todo_list / $todo_carousel_limit);
+        $last_page = intval(ceil($count_todo_list / $todo_carousel_limit));
 
         $contents = [];
         if ($current_page !== 1) {
@@ -829,7 +829,7 @@ class Todo extends Model
 
         if ($current_page !== $last_page) {
             // ラストページ以外の時
-            $next_todo_num = intval($last_page) === intval($current_page + 1) ? $count_todo_list - $todo_carousel_limit : $todo_carousel_limit;
+            $next_todo_num = intval($last_page) === intval($current_page + 1) ? $count_todo_list -  (9 + (($current_page - 1) * 10)) : $todo_carousel_limit;
             $text = '次の' . $next_todo_num . '件を見る';
             $next_btn = new ButtonComponentBuilder(
                 new PostbackTemplateActionBuilder(

--- a/web/app/Models/Todo.php
+++ b/web/app/Models/Todo.php
@@ -554,9 +554,9 @@ class Todo extends Model
             } else if ($date->isTomorrow()) {
                 $date_text = "明日まで";
             } else if ($date->isPast()) {
-                $date_text = $date->diffInDays(Carbon::now()) . "日経過";
+                $date_text = $date->diffInDays(Carbon::now()->setTime(0, 0, 0)) . "日経過";
             } else if ($date->isFuture()) {
-                $date_text = "残り" . $date->diffInDays(Carbon::now()) . "日";
+                $date_text = "残り" . $date->diffInDays(Carbon::now()->setTime(0, 0, 0)) . "日";
             }
         } else {
             $date_text = "日付:未設定";

--- a/web/app/Models/Todo.php
+++ b/web/app/Models/Todo.php
@@ -412,26 +412,36 @@ class Todo extends Model
      *
      * Todoをカウントした結果の数を表示するBubbleContainer
      *
+     * @param User $line_user
      * @param string $todo_type
      * @param int $count_todo_list
      * @return \LINE\LINEBot\MessageBuilder\Flex\ContainerBuilder\BubbleContainerBuilder;
      */
-    public static function createCountTodoBubbleContainer(string $todo_type, int $count_todo_list)
+    public static function createCountTodoBubbleContainer(User $line_user, string $action_type, int $count_todo_list)
     {
+        if ($action_type === 'ALL_TODO_LIST') {
+            $todo_type = 'プロジェクト:「' . $line_user->question->project->name . '」のやること';
+        } elseif ($action_type === 'WEEKLY_TODO_LIST') {
+            $todo_type = '今週までにやること';
+        }
+
         $result_count_todo_list_text = '📝' . ' ' . $count_todo_list;
         $result_count_todo_list_text_component  = new TextComponentBuilder($result_count_todo_list_text, 1);
-        $result_count_todo_list_text_component->setGravity('buttom');
+        $result_count_todo_list_text_component->setGravity('bottom');
         $result_count_todo_list_text_component->setAlign('center');
         $result_count_todo_list_text_component->setSize('5xl');
         $result_count_todo_list_text_component->setOffsetBottom('8px');
 
-        $report_count_todo_list_text = $todo_type . 'が' . "\n" . $count_todo_list . '件見つかりました';
+        $report_count_todo_list_text = $todo_type . 'が' . $count_todo_list . '件見つかりました';
         $report_count_todo_list_text_component  = new TextComponentBuilder($report_count_todo_list_text, 1);
         $report_count_todo_list_text_component->setAlign('center');
         $report_count_todo_list_text_component->setWeight('bold');
         $report_count_todo_list_text_component->setWrap(true);
 
-        $texts = [$result_count_todo_list_text, $report_count_todo_list_text];
+        $texts = [
+            $result_count_todo_list_text_component,
+            $report_count_todo_list_text_component
+        ];
         $body_box = new BoxComponentBuilder('vertical', $texts);
         $body_box->setSpacing('lg');
 

--- a/web/app/Models/Todo.php
+++ b/web/app/Models/Todo.php
@@ -404,11 +404,56 @@ class Todo extends Model
 
     /**
      *
+     * 一覧結果の数
+     *
+     */
+
+    /**
+     *
+     * Todoをカウントした結果の数を表示するBubbleContainer
+     *
+     * @param string $todo_type
+     * @param int $count_todo_list
+     * @return \LINE\LINEBot\MessageBuilder\Flex\ContainerBuilder\BubbleContainerBuilder;
+     */
+    public static function createCountTodoBubbleContainer(string $todo_type, int $count_todo_list)
+    {
+        $result_count_todo_list_text = '📝' . ' ' . $count_todo_list;
+        $result_count_todo_list_text_component  = new TextComponentBuilder($result_count_todo_list_text, 1);
+        $result_count_todo_list_text_component->setGravity('buttom');
+        $result_count_todo_list_text_component->setAlign('center');
+        $result_count_todo_list_text_component->setSize('5xl');
+        $result_count_todo_list_text_component->setOffsetBottom('8px');
+
+        $report_count_todo_list_text = $todo_type . 'が' . "\n" . $count_todo_list . '件見つかりました';
+        $report_count_todo_list_text_component  = new TextComponentBuilder($report_count_todo_list_text, 1);
+        $report_count_todo_list_text_component->setAlign('center');
+        $report_count_todo_list_text_component->setWeight('bold');
+        $report_count_todo_list_text_component->setWrap(true);
+
+        $texts = [$result_count_todo_list_text, $report_count_todo_list_text];
+        $body_box = new BoxComponentBuilder('vertical', $texts);
+        $body_box->setSpacing('lg');
+
+        $bubble_container = new BubbleContainerBuilder();
+        $bubble_container->setBody($body_box);
+        return $bubble_container;
+    }
+
+
+    /**
+     *
+     * やることのカルーセルカラム
+     *
+     */
+
+    /**
+     *
      * コンポーネントをひとまとめ。BubbleContainerの生成ビルダー
      *
      * @param Todo $todo
      * @param string $action_type
-     * @return \LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\TextComponentBuilder
+     * @return \LINE\LINEBot\MessageBuilder\Flex\ContainerBuilder\BubbleContainerBuilder;
      */
     public static function createBubbleContainer(Todo $todo, string $action_type)
     {

--- a/web/app/Models/Todo.php
+++ b/web/app/Models/Todo.php
@@ -797,11 +797,13 @@ class Todo extends Model
      *
      * Todoをカウントした結果の数を表示するBubbleContainer
      *
+     * @param int $todo_carousel_limit
      * @param int $current_page
      * @param int $count_todo_list
+     * @param string $action_value
      * @return \LINE\LINEBot\MessageBuilder\Flex\ContainerBuilder\BubbleContainerBuilder;
      */
-    public static function createViewMoreBubbleContainer(int $todo_carousel_limit, int $current_page, int $count_todo_list)
+    public static function createViewMoreBubbleContainer(int $todo_carousel_limit, int $current_page, int $count_todo_list, $action_value)
     {
         $last_page = ceil($count_todo_list / $todo_carousel_limit);
 
@@ -812,7 +814,7 @@ class Todo extends Model
             $prev_btn = new ButtonComponentBuilder(
                 new PostbackTemplateActionBuilder(
                     $text,
-                    'action=PREV_TODO_LIST&page=' . $current_page - 1
+                    'action=' . $action_value . '&page=' . $current_page - 1
                 ),
                 1 //flex
             );
@@ -832,7 +834,7 @@ class Todo extends Model
             $next_btn = new ButtonComponentBuilder(
                 new PostbackTemplateActionBuilder(
                     $text,
-                    'action=NEXT_TODO_LIST&page=' . $current_page + 1
+                    'action=' . $action_value . '&page=' . $current_page + 1
                 ),
                 1 // flex
             );

--- a/web/app/Models/Todo.php
+++ b/web/app/Models/Todo.php
@@ -817,17 +817,17 @@ class Todo extends Model
                 1 //flex
             );
             $prev_btn->setGravity('center');
-            $content[] = $prev_btn;
+            $contents[] = $prev_btn;
         }
 
         if ($current_page !== 1 && $current_page !== $last_page) {
             # 1ページ目でも最後のページでもない時
-            $content[] = new SeparatorComponentBuilder();
+            $contents[] = new SeparatorComponentBuilder();
         }
 
         if ($current_page !== $last_page) {
             // ラストページ以外の時
-            $next_todo_num = $last_page === $current_page + 1 ? $count_todo_list - $todo_carousel_limit : $todo_carousel_limit;
+            $next_todo_num = intval($last_page) === intval($current_page + 1) ? $count_todo_list - $todo_carousel_limit : $todo_carousel_limit;
             $text = '次の' . $next_todo_num . '件を見る';
             $next_btn = new ButtonComponentBuilder(
                 new PostbackTemplateActionBuilder(
@@ -837,7 +837,7 @@ class Todo extends Model
                 1 // flex
             );
             $next_btn->setGravity('center');
-            $content[] = $next_btn;
+            $contents[] = $next_btn;
         }
 
         $body_box = new BoxComponentBuilder('vertical', $contents);

--- a/web/app/Models/Todo.php
+++ b/web/app/Models/Todo.php
@@ -420,10 +420,12 @@ class Todo extends Model
      */
     public static function createCountTodoBubbleContainer(User $line_user, string $action_type, int $count_todo_list)
     {
-        if ($action_type === 'ALL_TODO_LIST') {
+        if ($action_type === 'ALL_TODO_LIST' || $action_type === 'SELECT_TODO_LIST_TO_CHECK') {
             $todo_type = 'プロジェクト:「' . $line_user->question->project->name . '」のやること';
-        } elseif ($action_type === 'WEEKLY_TODO_LIST') {
+        } elseif ($action_type === 'WEEKLY_TODO_LIST' || 'CHECK_TODO_BY_THIS_WEEK') {
             $todo_type = '今週までにやること';
+        } elseif ($action_type === 'CHECK_TODO_BY_TODAY') {
+            $todo_type = '今日までにやること';
         }
 
         $result_count_todo_list_text = '📝' . ' ' . $count_todo_list;

--- a/web/app/Repositories/Todo/TodoRepository.php
+++ b/web/app/Repositories/Todo/TodoRepository.php
@@ -112,8 +112,8 @@ class TodoRepository implements TodoRepositoryInterface
         $delete_child = $this->client->run(
             <<<'CYPHER'
                 MATCH (user:User { uuid : $user_uuid }) - [r1] -> (todo:Todo{ uuid :$uuid }) ,
-                 (child:Todo) - [*] -> (todo) - [r2] -> (parent),
-                 (todo) - [r3] - (),
+                (todo) - [r2] - ()
+                OPTIONAL MATCH (child:Todo) - [*] -> (todo) - [r3] -> (parent),
                  (child) - [r4] - ()
                 DELETE r1, r2, r3, r4, todo, child
                 RETURN child

--- a/web/app/UseCases/Line/PostbackReceivedAction.php
+++ b/web/app/UseCases/Line/PostbackReceivedAction.php
@@ -95,8 +95,6 @@ class PostbackReceivedAction
         [$action_key, $action_value] = explode("=", $action_data);
         [$second_key, $second_value] = explode("=", $uuid_data);
 
-        Log::debug($action_value);
-        Log::debug($second_value);
         if (isset(LineUsersQuestion::TODO_LIST[$action_value])) {
             $this->select_todo_list_action->invoke($event, $line_user, $action_value, $second_value);
         } else if ($action_value === 'ADD_TODO') {

--- a/web/app/UseCases/Line/PostbackReceivedAction.php
+++ b/web/app/UseCases/Line/PostbackReceivedAction.php
@@ -95,6 +95,8 @@ class PostbackReceivedAction
         [$action_key, $action_value] = explode("=", $action_data);
         [$second_key, $second_value] = explode("=", $uuid_data);
 
+        Log::debug($action_value);
+        Log::debug($second_value);
         if (isset(LineUsersQuestion::TODO_LIST[$action_value])) {
             $this->select_todo_list_action->invoke($event, $line_user, $action_value, $second_value);
         } else if ($action_value === 'ADD_TODO') {

--- a/web/app/UseCases/Line/PostbackReceivedAction.php
+++ b/web/app/UseCases/Line/PostbackReceivedAction.php
@@ -93,35 +93,35 @@ class PostbackReceivedAction
         //postbackのデータをactionとuuidで分割
         list($action_data, $uuid_data) = explode("&", $event->getPostbackData());
         [$action_key, $action_value] = explode("=", $action_data);
-        [$uuid_key, $uuid_value] = explode("=", $uuid_data);
+        [$second_key, $second_value] = explode("=", $uuid_data);
 
         if (isset(LineUsersQuestion::TODO_LIST[$action_value])) {
-            $this->select_todo_list_action->invoke($event, $line_user, $action_value);
+            $this->select_todo_list_action->invoke($event, $line_user, $action_value, $second_value);
         } else if ($action_value === 'ADD_TODO') {
-            if ($uuid_value) {
-                $parent_todo = Todo::where('uuid', $uuid_value)->first();
+            if ($second_value) {
+                $parent_todo = Todo::where('uuid', $second_value)->first();
                 // 返信メッセージ
                 $this->bot->replyText($event->getReplyToken(), Todo::askTodoName($parent_todo));
                 //質問の更新
                 $line_user->question->update([
                     'question_number' => LineUsersQuestion::TODO,
-                    'parent_uuid' => $uuid_value,
+                    'parent_uuid' => $second_value,
                 ]);
             }
         } else if ($action_value === 'LIMIT_DATE') {
             // 日付に関する質問の場合
-            $this->date_response_action->invoke($event, $line_user, $uuid_value);
+            $this->date_response_action->invoke($event, $line_user, $second_value);
         } else if ($action_value === 'CHANGE_TODO') {
-            $builder = Todo::changeTodo(Todo::where('uuid', $uuid_value)->first());
+            $builder = Todo::changeTodo(Todo::where('uuid', $second_value)->first());
             $this->bot->replyMessage($event->getReplyToken(), $builder);
         } else if ($action_value === 'RENAME_TODO') {
-            $this->rename_todo->invoke($event, $line_user, $uuid_value);
+            $this->rename_todo->invoke($event, $line_user, $second_value);
         } else if (isset(LineUsersQuestion::DELETE_TODO[$action_value])) {
-            $this->delete_todo->invoke($event, $line_user, $action_value, $uuid_value);
+            $this->delete_todo->invoke($event, $line_user, $action_value, $second_value);
         } else if (isset(LineUsersQuestion::CHANGE_DATE[$action_value])) {
-            $this->change_date->invoke($event, $line_user, $action_value, $uuid_value);
+            $this->change_date->invoke($event, $line_user, $action_value, $second_value);
         } else if (isset(CheckedTodo::CHECK_TODO[$action_value])) {
-            $this->check_todo->invoke($event, $line_user, $action_value, $uuid_value);
+            $this->check_todo->invoke($event, $line_user, $action_value, $second_value);
         }
         return;
     }

--- a/web/app/UseCases/Line/Todo/CheckTodo.php
+++ b/web/app/UseCases/Line/Todo/CheckTodo.php
@@ -73,6 +73,7 @@ class CheckTodo
                 $next_week = $today_date_time->modify('+1 week')->format('Y-m-d');
                 $todo_list = Todo::where('user_uuid', $line_user->uuid)
                     ->whereBetween('date', [$today, $next_week])
+                    ->orderBy('date', 'asc')
                     ->get();
             } elseif ($action_type === 'SELECT_TODO_LIST_TO_CHECK') {
                 $todo_list = $line_user->todo;
@@ -85,13 +86,18 @@ class CheckTodo
                 }
             }
 
-            $over_due_todo_list = Todo::where('user_uuid', $line_user->uuid)
-                ->where('date', '<', $today);
-            foreach ($over_due_todo_list as $over_due_todo) {
-                if ($over_due_todo->accomplish === null) {
-                    $todo_carousel_columns[] = Todo::createBubbleContainer($over_due_todo, $action_type);
+            if (
+                $action_type === 'CHECK_TODO_BY_TODAY' || $action_type === 'CHECK_TODO_BY_THIS_WEEK'
+            ) {
+                $over_due_todo_list = Todo::where('user_uuid', $line_user->uuid)
+                    ->where('date', '<', $today);
+                foreach ($over_due_todo_list as $over_due_todo) {
+                    if (count($over_due_todo->accomplish) === 0) {
+                        $todo_carousel_columns[] = Todo::createBubbleContainer($over_due_todo, $action_type);
+                    }
                 }
             }
+
             $message = Todo::createTodoListTitleMessage($line_user, $action_type, $todo_carousel_columns);
 
             // 該当のTodoがある場合

--- a/web/app/UseCases/Line/Todo/CreateTodoListCarouselColumns.php
+++ b/web/app/UseCases/Line/Todo/CreateTodoListCarouselColumns.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\UseCases\Line\Todo;
+
+use App\Models\User;
+use App\Models\Todo;
+use DateTime;
+
+class CreateTodoListCarouselColumns
+{
+    /**
+     *
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * 受け取ったメッセージを場合分けしていく
+     *
+     * @param User $line_user
+     * @param object $todo_list
+     * @param string $action_type
+     * @param string $current_page
+     * @return
+     */
+    public function invoke(User $line_user, object $todo_list, string $action_type, string $current_page)
+    {
+        $current_page = intval($current_page);
+
+        $today_date_time = new DateTime();
+        $today = $today_date_time->format('Y-m-d');
+
+
+        $todo_carousel_columns = [];
+        foreach ($todo_list as $todo) {
+            if (count($todo->accomplish) === 0) {
+                $todo_carousel_columns[] = Todo::createBubbleContainer($todo, $action_type);
+            }
+        }
+
+        if (
+            $action_type === 'WEEKLY_TODO_LIST' ||
+            $action_type === 'CHECK_TODO_BY_TODAY' ||
+            $action_type === 'CHECK_TODO_BY_THIS_WEEK'
+        ) {
+            $over_due_todo_list = Todo::where('user_uuid', $line_user->uuid)
+                ->where('date', '<', $today)
+                ->orderBy('date', 'asc')
+                ->get();
+            foreach ($over_due_todo_list as $over_due_todo) {
+                if (count($over_due_todo->accomplish) === 0) {
+                    $todo_carousel_columns[] = Todo::createBubbleContainer($over_due_todo, $action_type);
+                }
+            }
+        }
+
+        $count_todo_carousel_column = count($todo_carousel_columns);
+
+        // Todoが8件以上ある時
+        if ($count_todo_carousel_column > 9) {
+            $todo_carousel_limit = $current_page === 1 ? 9 : 10;
+            $slice_start = $current_page === 1 ? 0 : 9 + (($current_page - 2) * 10);
+            $todo_carousel_columns = array_slice($todo_carousel_columns, $slice_start, $todo_carousel_limit);
+            $todo_carousel_columns[] = Todo::createViewMoreBubbleContainer($todo_carousel_limit, $current_page, $count_todo_carousel_column, $action_type);
+        }
+
+        // Todoが何件あるか報告するメッセージ
+        if ($current_page === 1) {
+            $report_message = Todo::createCountTodoBubbleContainer($line_user, $action_type, $count_todo_carousel_column);
+            array_unshift($todo_carousel_columns, $report_message);
+        }
+
+        return $todo_carousel_columns;
+    }
+}

--- a/web/app/UseCases/Line/Todo/SelectTodoListAction.php
+++ b/web/app/UseCases/Line/Todo/SelectTodoListAction.php
@@ -44,7 +44,7 @@ class SelectTodoListAction
         $today = $today_date_time->format('Y-m-d');
         if ($action_value === 'ALL_TODO_LIST') {
             $todo_list = $line_user->todo;
-        } else if ($action_value === 'WEEKLY_TODO_LIST') {
+        } elseif ($action_value === 'WEEKLY_TODO_LIST') {
             $next_week_date_time = $today_date_time->modify('+1 week');
             $next_week = $next_week_date_time->format('Y-m-d');
             $todo_list = Todo::where('user_uuid', $line_user->uuid)
@@ -75,28 +75,19 @@ class SelectTodoListAction
         }
 
         // Todoが何件あるか報告するメッセージ
-        $message = Todo::createTodoListTitleMessage($line_user, $action_value, $todo_carousel_columns);
+        $report_message = Todo::createCountTodoBubbleContainer($line_user, $action_value, count($todo_carousel_columns));
+        array_unshift($todo_carousel_columns, $report_message);
 
-        if (count($todo_carousel_columns) > 0) {
-            $todo_carousels = new CarouselContainerBuilder($todo_carousel_columns);
-            $flex_message = new FlexMessageBuilder(
-                'やること一覧',
-                $todo_carousels
-            );
-            $builder = new \LINE\LINEBot\MessageBuilder\MultiMessageBuilder();
-            $builder->add(
-                new \LINE\LINEBot\MessageBuilder\TextMessageBuilder($message['text'])
-            );
-            $builder->add($flex_message);
-        } else {
-            $builder = new \LINE\LINEBot\MessageBuilder\TextMessageBuilder($message['text']);
-        }
-
-
-        $this->bot->replyMessage(
-            $event->getReplyToken(),
-            $builder
+        $todo_carousels = new CarouselContainerBuilder($todo_carousel_columns);
+        $flex_message = new FlexMessageBuilder(
+            'やること一覧',
+            $todo_carousels
         );
+        $log = $this->bot->replyMessage(
+            $event->getReplyToken(),
+            $flex_message
+        );
+        Log::debug((array)$log);
         return;
     }
 }

--- a/web/app/UseCases/Line/Todo/SelectTodoListAction.php
+++ b/web/app/UseCases/Line/Todo/SelectTodoListAction.php
@@ -100,11 +100,10 @@ class SelectTodoListAction
             'やること一覧',
             $todo_carousels
         );
-        $log = $this->bot->replyMessage(
+        $this->bot->replyMessage(
             $event->getReplyToken(),
             $flex_message
         );
-        Log::debug((array)$log);
         return;
     }
 }

--- a/web/app/UseCases/Line/Todo/SelectTodoListAction.php
+++ b/web/app/UseCases/Line/Todo/SelectTodoListAction.php
@@ -36,10 +36,15 @@ class SelectTodoListAction
      * 受け取ったメッセージを場合分けしていく
      *
      * @param object $event
+     * @param User $line_user
+     * @param string $action_value
+     * @param string $current_page
      * @return
      */
-    public function invoke(object $event, User $line_user, string $action_value)
+    public function invoke(object $event, User $line_user, string $action_value, string $current_page)
     {
+        $current_page = intval($current_page);
+
         $today_date_time = new DateTime();
         $today = $today_date_time->format('Y-m-d');
         if ($action_value === 'ALL_TODO_LIST') {
@@ -74,8 +79,18 @@ class SelectTodoListAction
             }
         }
 
+        $count_todo_carousel_column = count($todo_carousel_columns);
+
+        // Todoが8件以上ある時
+        if ($count_todo_carousel_column > 9) {
+            $todo_carousel_limit = $current_page === 1 ? 9 : 10;
+            $slice_start = $current_page === 1 ? 0 : ($todo_carousel_limit - 1) + (($current_page - 1) * 10);
+            $todo_carousel_columns = array_slice($todo_carousel_columns, $slice_start, $todo_carousel_limit);
+            $todo_carousel_columns[] = Todo::createViewMoreBubbleContainer($todo_carousel_limit, $current_page, $count_todo_carousel_column);
+        }
+
         // Todoが何件あるか報告するメッセージ
-        $report_message = Todo::createCountTodoBubbleContainer($line_user, $action_value, count($todo_carousel_columns));
+        $report_message = Todo::createCountTodoBubbleContainer($line_user, $action_value, $count_todo_carousel_column);
         array_unshift($todo_carousel_columns, $report_message);
 
         $todo_carousels = new CarouselContainerBuilder($todo_carousel_columns);

--- a/web/app/UseCases/Line/Todo/SelectTodoListAction.php
+++ b/web/app/UseCases/Line/Todo/SelectTodoListAction.php
@@ -51,14 +51,15 @@ class SelectTodoListAction
                 ->whereBetween('date', [$today, $next_week])
                 ->orderBy('date', 'asc')
                 ->get();
-            Log::debug((array)$todo_list);
         } else {
             $todo_list = [];
         }
 
         $todo_carousel_columns = [];
         foreach ($todo_list as $todo) {
-            $todo_carousel_columns[] = Todo::createBubbleContainer($todo, $action_value);
+            if (count($todo->accomplish) === 0) {
+                $todo_carousel_columns[] = Todo::createBubbleContainer($todo, $action_value);
+            }
         }
 
         if ($action_value === 'WEEKLY_TODO_LIST') {
@@ -73,7 +74,6 @@ class SelectTodoListAction
             }
         }
 
-        Log::debug($todo_carousel_columns);
         // Todoが何件あるか報告するメッセージ
         $message = Todo::createTodoListTitleMessage($line_user, $action_value, $todo_carousel_columns);
 

--- a/web/app/UseCases/Line/Todo/SelectTodoListAction.php
+++ b/web/app/UseCases/Line/Todo/SelectTodoListAction.php
@@ -84,14 +84,16 @@ class SelectTodoListAction
         // Todoが8件以上ある時
         if ($count_todo_carousel_column > 9) {
             $todo_carousel_limit = $current_page === 1 ? 9 : 10;
-            $slice_start = $current_page === 1 ? 0 : ($todo_carousel_limit - 1) + (($current_page - 1) * 10);
+            $slice_start = $current_page === 1 ? 0 : 9 + (($current_page - 2) * 10);
             $todo_carousel_columns = array_slice($todo_carousel_columns, $slice_start, $todo_carousel_limit);
-            $todo_carousel_columns[] = Todo::createViewMoreBubbleContainer($todo_carousel_limit, $current_page, $count_todo_carousel_column);
+            $todo_carousel_columns[] = Todo::createViewMoreBubbleContainer($todo_carousel_limit, $current_page, $count_todo_carousel_column, $action_value);
         }
 
         // Todoが何件あるか報告するメッセージ
-        $report_message = Todo::createCountTodoBubbleContainer($line_user, $action_value, $count_todo_carousel_column);
-        array_unshift($todo_carousel_columns, $report_message);
+        if ($current_page === 1) {
+            $report_message = Todo::createCountTodoBubbleContainer($line_user, $action_value, $count_todo_carousel_column);
+            array_unshift($todo_carousel_columns, $report_message);
+        }
 
         $todo_carousels = new CarouselContainerBuilder($todo_carousel_columns);
         $flex_message = new FlexMessageBuilder(


### PR DESCRIPTION
## URL

*

## 背景

* 9件以上になるとカルーセルが出せなくなる
* なので9件以上あった時はもっと見るのカルーセルを用意する
* 今現在日にちが過ぎたものが見えなくなってるぽいのでそこをまずなんとかする

## todo

- [x] 期限切れのやることを映す
- [x] もっと見るのカルーセルを作る
- [x] やること一覧で件数カルーセルともっと見るカルーセル追加
- [x] 振り返りで件数カルーセルともっと見るカルーセル追加

## 影響範囲

* 

## テスト

* 

## 参考資料

* 

## 保留したこと

* 

## その他

* 
