### PR TITLE
通知の時間を探すときのフォーマットが間違えてた

### DIFF
--- a/web/app/Models/TodoCheckNotificationDateTime.php
+++ b/web/app/Models/TodoCheckNotificationDateTime.php
@@ -86,7 +86,7 @@ class TodoCheckNotificationDateTime extends Model
             $notification_date = $notification_date_time->notification_date === 7 ?
                 "毎日" : "毎週" . $week_day[$notification_date_time->notification_date] . "曜日";
             $notification_time = $notification_date_time->notification_time;
-            $title = "振り返りの時間: " . $notification_date  . $notification_time;
+            $title = "振り返りの時間: " . $notification_date  . mb_substr($notification_time, 0, 5);
             $text = "現在振り返りの時間を" . $notification_date  . $notification_time . "に設定されています。";
             $actions = [
                 new PostbackTemplateActionBuilder("振り返りの曜日・時間の変更", 'action=SETTING_NOTIFY_DAY_OF_WEEK&value='),

--- a/web/app/UseCases/Line/FollowAction.php
+++ b/web/app/UseCases/Line/FollowAction.php
@@ -66,7 +66,7 @@ class FollowAction
             TodoCheckNotificationDateTime::create([
                 'user_uuid' => $user['uuid'],
                 'notification_date' => 0,
-                'notification_time' => '21:00'
+                'notification_time' => '21:00:00'
             ]);
 
             // userをneo4jのDBにも登録

--- a/web/app/UseCases/Line/Todo/Notification/NotifyTodoCheck.php
+++ b/web/app/UseCases/Line/Todo/Notification/NotifyTodoCheck.php
@@ -3,6 +3,7 @@
 namespace App\UseCases\Line\Todo\Notification;
 
 use App\Models\CheckedTodo;
+use App\Models\LineUsersQuestion;
 use App\Models\Todo;
 use App\Models\TodoCheckNotificationDateTime;
 use App\UseCases\Line\Todo\CreateTodoListCarouselColumns as TodoCreateTodoListCarouselColumns;
@@ -71,7 +72,7 @@ class NotifyTodoCheck
                         $action_type,
                         $current_page = 1
                     );
-                    $recive_notification_user->question->update([
+                    LineUsersQuestion::where('user_uuid', $recive_notification_user->users->uuid)->update([
                         'checked_todo' => CheckedTodo::CHECK_TODO[$action_type]
                     ]);
                 } else {
@@ -89,7 +90,7 @@ class NotifyTodoCheck
                 $multi_message_builder = new MultiMessageBuilder();
                 $multi_message_builder->add(new TextMessageBuilder($notify_todo_check_message));
                 $multi_message_builder->add($second_message);
-                $log = $this->bot->pushMessage(
+                $this->bot->pushMessage(
                     $recive_notification_user->users->line_user_id,
                     $multi_message_builder
                 );

--- a/web/app/UseCases/Line/Todo/Notification/NotifyTodoCheck.php
+++ b/web/app/UseCases/Line/Todo/Notification/NotifyTodoCheck.php
@@ -51,9 +51,6 @@ class NotifyTodoCheck
                 $query->orwhere('notification_date', 7)
                     ->orwhere('notification_date', $day_of_week);
             })->get();
-        Log::debug($time);
-        Log::debug((array)$recive_notification_users);
-        Log::debug(count($recive_notification_users));
         if (count($recive_notification_users) > 0) {
             Log::info('has');
             foreach ($recive_notification_users as  $recive_notification_user) {
@@ -96,7 +93,6 @@ class NotifyTodoCheck
                     $recive_notification_user->users->line_user_id,
                     $multi_message_builder
                 );
-                Log::debug((array)$log);
             }
         }
         return;

--- a/web/app/UseCases/Line/Todo/Notification/NotifyTodoCheck.php
+++ b/web/app/UseCases/Line/Todo/Notification/NotifyTodoCheck.php
@@ -44,7 +44,7 @@ class NotifyTodoCheck
     {
         Log::info('success');
         $datetime = new DateTime();
-        $time = $datetime->format('H') . ':00';
+        $time = $datetime->format('H') . ':00:00';
         $day_of_week = date('w');
         $recive_notification_users = TodoCheckNotificationDateTime::where('notification_time', $time)
             ->where(function ($query) use ($day_of_week) {

--- a/web/app/UseCases/Line/Todo/Notification/SetupNotificationForTodoCheck.php
+++ b/web/app/UseCases/Line/Todo/Notification/SetupNotificationForTodoCheck.php
@@ -102,7 +102,7 @@ class SetupNotificationForTodoCheck
                 ['user_uuid' => $line_user->uuid],
                 [
                     'notification_date' => (int)$day_of_week,
-                    'notification_time' => $time
+                    'notification_time' => $time . ':00'
                 ]
             );
         }


### PR DESCRIPTION
## URL

*

## 背景

* 保存の状態がhh:ii:ssにも関わらず探すときの状態がhh::iiになっているので通知が来ない

## todo

- [ ] hh::ii:ssに直す
- [ ] 通知の設定画面で表示する時はhh::iiにする

## 影響範囲

* 

## テスト

* 

## 参考資料

* 

## 保留したこと

* 

## その他

* 
