### PR TITLE
todoの文字数制限

### DIFF
--- a/web/app/Models/Todo.php
+++ b/web/app/Models/Todo.php
@@ -652,8 +652,8 @@ class Todo extends Model
             $subtitle_text = 'プロジェクト:「' . $todo->project->name . '」のゴール';
         } else {
             $parent_todo = Todo::where('uuid', $todo->parent_uuid)->first();
-            $todo_or_habit = $todo->habit() ? '習慣' : 'こと';
-            $subtitle_text = '「' . $parent_todo->name . '」のためにやる' . $todo_or_habit . 'こと';
+            $todo_or_habit = count($todo->habit) > 0 ? '習慣' : 'こと';
+            $subtitle_text = '「' . $parent_todo->name . '」のためにやる' . $todo_or_habit;
         }
         $subtitle_text_component = new TextComponentBuilder($subtitle_text);
         $subtitle_text_component->setSize("xxs");

--- a/web/app/UseCases/Line/TodoResponseAction.php
+++ b/web/app/UseCases/Line/TodoResponseAction.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Str;
 use LINE\LINEBot\HTTPClient\CurlHTTPClient;
 use LINE\LINEBot;
 use DateTime;
+use Illuminate\Support\Facades\Log;
 
 
 class TodoResponseAction
@@ -68,6 +69,9 @@ class TodoResponseAction
      */
     public function invoke(object $event, User $line_user, int $question_number)
     {
+        if (mb_strlen($event->getText()) > 36) {
+            $this->bot->replyText($event->getReplyToken(), '36文字以内での入力でお願いします!');
+        }
         $parentTodo = Todo::where('uuid', $line_user->question->parent_uuid)->first();
         $depth = $parentTodo ? (int)$parentTodo->depth + 1 : 0;
 

--- a/web/app/UseCases/Line/TodoResponseAction.php
+++ b/web/app/UseCases/Line/TodoResponseAction.php
@@ -12,9 +12,6 @@ use App\Repositories\Line\LineBotRepositoryInterface;
 use Illuminate\Support\Str;
 use LINE\LINEBot\HTTPClient\CurlHTTPClient;
 use LINE\LINEBot;
-use DateTime;
-use Illuminate\Support\Facades\Log;
-
 
 class TodoResponseAction
 {


### PR DESCRIPTION
## URL

*

## 背景

* todoの文字数制限をしないとカルーセルが伸びる
* あと削除ができなくなる.何故ならテンプレートメッセージのタイトルが40文字以内なので

## todo

- [x] 文字数制限する

## 影響範囲

* 

## テスト

* 

## 参考資料

* 

## 保留したこと

* 

## その他

* 
