### PR TITLE
リッチメニューを変えます

### DIFF
--- a/web/app/Models/CheckedTodo.php
+++ b/web/app/Models/CheckedTodo.php
@@ -172,8 +172,6 @@ class CheckedTodo extends Model
      *
      * 振り返りのフレックスメッセージ
      *
-     * @return \LINE\LINEBot\MessageBuilder\FlexMessageBuilder;
-     *
      */
     public static function createCheckTodoFlexMessage()
     {

--- a/web/app/Services/MessageBuilder/Carousel/OtherMenuCarousels.php
+++ b/web/app/Services/MessageBuilder/Carousel/OtherMenuCarousels.php
@@ -27,4 +27,15 @@ use LINE\LINEBot\MessageBuilder\FlexMessageBuilder;
  */
 class OtherMenuCarousels
 {
+    public static function createFlexMessageBuilder()
+    {
+    }
+
+    public static function createCrouselContainerBuilder()
+    {
+    }
+
+    public static function createBubbleContainerBuilder()
+    {
+    }
 }

--- a/web/app/Services/MessageBuilder/Carousel/OtherMenuCarousels.php
+++ b/web/app/Services/MessageBuilder/Carousel/OtherMenuCarousels.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services;
+
+use LINE\LINEBot\MessageBuilder\TemplateBuilder\ButtonTemplateBuilder;
+use LINE\LINEBot\TemplateActionBuilder\DatetimePickerTemplateActionBuilder;
+use LINE\LINEBot\TemplateActionBuilder\PostbackTemplateActionBuilder;
+use LINE\LINEBot\MessageBuilder\TextMessageBuilder;
+use LINE\LINEBot\MessageBuilder\TemplateMessageBuilder;
+use LINE\LINEBot\MessageBuilder\TemplateBuilder\CarouselColumnTemplateBuilder;
+use LINE\LINEBot\MessageBuilder\TemplateBuilder\ConfirmTemplateBuilder;
+use LINE\LINEBot\MessageBuilder\TemplateBuilder\CarouselTemplateBuilder;
+use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\BoxComponentBuilder;
+use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\TextComponentBuilder;
+use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\IconComponentBuilder;
+use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\ButtonComponentBuilder;
+use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\SeparatorComponentBuilder;
+use LINE\LINEBot\MessageBuilder\Flex\BlockStyleBuilder;
+use LINE\LINEBot\MessageBuilder\Flex\BubbleStylesBuilder;
+use LINE\LINEBot\MessageBuilder\Flex\ContainerBuilder\BubbleContainerBuilder;
+use LINE\LINEBot\MessageBuilder\Flex\ContainerBuilder\CarouselContainerBuilder;
+use LINE\LINEBot\MessageBuilder\MultiMessageBuilder;
+use LINE\LINEBot\MessageBuilder\FlexMessageBuilder;
+
+/**
+ * Neo4jのDBを呼び出す処理をFacadeを使って共通化
+ */
+class OtherMenuCarousels
+{
+}

--- a/web/app/Services/MessageBuilder/Carousel/OtherMenuCarousels.php
+++ b/web/app/Services/MessageBuilder/Carousel/OtherMenuCarousels.php
@@ -2,24 +2,11 @@
 
 namespace App\Services;
 
-use LINE\LINEBot\MessageBuilder\TemplateBuilder\ButtonTemplateBuilder;
-use LINE\LINEBot\TemplateActionBuilder\DatetimePickerTemplateActionBuilder;
 use LINE\LINEBot\TemplateActionBuilder\PostbackTemplateActionBuilder;
-use LINE\LINEBot\MessageBuilder\TextMessageBuilder;
-use LINE\LINEBot\MessageBuilder\TemplateMessageBuilder;
-use LINE\LINEBot\MessageBuilder\TemplateBuilder\CarouselColumnTemplateBuilder;
-use LINE\LINEBot\MessageBuilder\TemplateBuilder\ConfirmTemplateBuilder;
-use LINE\LINEBot\MessageBuilder\TemplateBuilder\CarouselTemplateBuilder;
 use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\BoxComponentBuilder;
 use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\TextComponentBuilder;
-use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\IconComponentBuilder;
-use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\ButtonComponentBuilder;
-use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\SeparatorComponentBuilder;
-use LINE\LINEBot\MessageBuilder\Flex\BlockStyleBuilder;
-use LINE\LINEBot\MessageBuilder\Flex\BubbleStylesBuilder;
 use LINE\LINEBot\MessageBuilder\Flex\ContainerBuilder\BubbleContainerBuilder;
 use LINE\LINEBot\MessageBuilder\Flex\ContainerBuilder\CarouselContainerBuilder;
-use LINE\LINEBot\MessageBuilder\MultiMessageBuilder;
 use LINE\LINEBot\MessageBuilder\FlexMessageBuilder;
 
 /**
@@ -27,15 +14,55 @@ use LINE\LINEBot\MessageBuilder\FlexMessageBuilder;
  */
 class OtherMenuCarousels
 {
+    const OTHER_MENUS = [
+        [
+            'text' => '🛠️ 使い方',
+            'postback_data' => ''
+        ],
+        [
+            'text' => '🔔 通知の設定',
+            'postback_data' => 'action=IF_YOU_WANT_TO_SET_UP_NOTIFY_CHECK_TODO&value='
+        ],
+        [
+            'text' => '📭 お問い合わせ',
+            'postback_data' => 'action=CONTACT_OR_FEEDBACKvalue='
+        ]
+    ];
+
     public static function createFlexMessageBuilder()
     {
+        $carousel_container_builder = OtherMenuCarousels::createCrouselContainerBuilder();
+        return new FlexMessageBuilder('メニュー：その他', $carousel_container_builder);
     }
 
     public static function createCrouselContainerBuilder()
     {
+        $bubble_container_builders = [];
+        for ($num = 0; $num < count(OtherMenuCarousels::OTHER_MENUS); $num++) {
+            $bubble_container_builders[] = OtherMenuCarousels::createBubbleContainerBuilder(
+                OtherMenuCarousels::OTHER_MENUS[$num]
+            );
+        }
+        return new CarouselContainerBuilder($bubble_container_builders);
     }
 
-    public static function createBubbleContainerBuilder()
+    public static function createBubbleContainerBuilder($menu)
     {
+        $text_component_builders = new TextComponentBuilder($menu['text']);
+        $text_component_builders->setWeight('bold');
+        $text_component_builders->setAlign('center');
+        $text_component_builders->setSize('lg');
+
+        $body_box = new BoxComponentBuilder('vertical', [$text_component_builders]);
+        $body_box->setHeight('120px');
+        $body_box->setJustifyContent('center');
+
+        $bubble_container_builder = new BubbleContainerBuilder();
+        $bubble_container_builder->setBody($body_box);
+        $bubble_container_builder->setSize('micro');
+        $template_action_builder = new PostbackTemplateActionBuilder($menu['text'], $menu['postback_data']);
+        $bubble_container_builder->setAction($template_action_builder);
+
+        return $bubble_container_builder;
     }
 }

--- a/web/app/Services/MessageBuilder/Carousels/OtherMenuCarousels.php
+++ b/web/app/Services/MessageBuilder/Carousels/OtherMenuCarousels.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services;
+namespace App\Services\Carousels\MessageBuilder;
 
 use LINE\LINEBot\TemplateActionBuilder\PostbackTemplateActionBuilder;
 use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\BoxComponentBuilder;

--- a/web/app/Services/MessageBuilder/Carousels/OtherMenuCarousels.php
+++ b/web/app/Services/MessageBuilder/Carousels/OtherMenuCarousels.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Services\Carousels\MessageBuilder;
+namespace App\Services\MessageBuilder\Carousels;
 
 use LINE\LINEBot\TemplateActionBuilder\PostbackTemplateActionBuilder;
 use LINE\LINEBot\MessageBuilder\Flex\ComponentBuilder\BoxComponentBuilder;
@@ -17,7 +17,7 @@ class OtherMenuCarousels
     const OTHER_MENUS = [
         [
             'text' => '🛠️ 使い方',
-            'postback_data' => ''
+            'postback_data' => 'action=&value='
         ],
         [
             'text' => '🔔 通知の設定',
@@ -25,7 +25,7 @@ class OtherMenuCarousels
         ],
         [
             'text' => '📭 お問い合わせ',
-            'postback_data' => 'action=CONTACT_OR_FEEDBACKvalue='
+            'postback_data' => 'action=CONTACT_OR_FEEDBACK&value='
         ]
     ];
 

--- a/web/app/UseCases/Line/MessageReceivedAction.php
+++ b/web/app/UseCases/Line/MessageReceivedAction.php
@@ -7,7 +7,7 @@ use App\Models\User;
 use App\Models\Todo;
 use App\Models\LineUsersQuestion;
 use App\Models\Contact;
-use App\Services\Carousels\MessageBuilder\OtherMenuCarousels;
+use App\Services\MessageBuilder\Carousels\OtherMenuCarousels;
 use App\UseCases\Line\ProjectResponseAction;
 use LINE\LINEBot\HTTPClient\CurlHTTPClient;
 use LINE\LINEBot;
@@ -84,10 +84,11 @@ class MessageReceivedAction
             );
             if ($line_user->question->checked_todo) $line_user->question->update(['checked_todo' => null, 'parent_uuid' => null]);
         } else if ($event->getText() === 'その他') {
-            $this->bot->replyMessage(
+            $test = $this->bot->replyMessage(
                 $event->getReplyToken(),
                 OtherMenuCarousels::createFlexMessageBuilder()
             );
+            Log::debug((array)$test);
             if ($line_user->question->checked_todo) $line_user->question->update(['checked_todo' => null, 'parent_uuid' => null]);
         } else if ($question_number === LineUsersQuestion::NO_QUESTION) {
             // 質問がない場合

--- a/web/app/UseCases/Line/MessageReceivedAction.php
+++ b/web/app/UseCases/Line/MessageReceivedAction.php
@@ -7,8 +7,8 @@ use App\Models\User;
 use App\Models\Todo;
 use App\Models\LineUsersQuestion;
 use App\Models\Contact;
+use App\Services\Carousels\MessageBuilder\OtherMenuCarousels;
 use App\UseCases\Line\ProjectResponseAction;
-use App\UseCases\Line\Todo\Notification\NotifyTodoCheck;
 use LINE\LINEBot\HTTPClient\CurlHTTPClient;
 use LINE\LINEBot;
 use Illuminate\Support\Facades\Log;
@@ -71,7 +71,7 @@ class MessageReceivedAction
 
         $question_number = $line_user->question->question_number;
         if ($event->getText() === '振り返り') {
-            $test = $this->bot->replyMessage(
+            $this->bot->replyMessage(
                 $event->getReplyToken(),
                 CheckedTodo::createCheckTodoFlexMessage()
             );
@@ -83,10 +83,10 @@ class MessageReceivedAction
                 Todo::askAddOrList($line_user->name)
             );
             if ($line_user->question->checked_todo) $line_user->question->update(['checked_todo' => null, 'parent_uuid' => null]);
-        } else if ($event->getText() === 'お問い合わせ') {
+        } else if ($event->getText() === 'その他') {
             $this->bot->replyMessage(
                 $event->getReplyToken(),
-                Contact::createContactOrFeedbackMessageBuilder()
+                OtherMenuCarousels::createFlexMessageBuilder()
             );
             if ($line_user->question->checked_todo) $line_user->question->update(['checked_todo' => null, 'parent_uuid' => null]);
         } else if ($question_number === LineUsersQuestion::NO_QUESTION) {

--- a/web/app/UseCases/Line/PostbackReceivedAction.php
+++ b/web/app/UseCases/Line/PostbackReceivedAction.php
@@ -147,6 +147,11 @@ class PostbackReceivedAction
         } else if (isset(TodoCheckNotificationDateTime::SETTING_NOTIFICATION_FOR_TODO_CHECK[$action_type])) {
             $notify_check_todo = new SetupNotificationForTodoCheck();
             $notify_check_todo->invoke($event, $line_user, $action_type, $second_value);
+        } else if ($action_type === 'CONTACT_OR_FEEDBACK') {
+            $this->bot->replyMessage(
+                $event->getReplyToken(),
+                Contact::createContactOrFeedbackMessageBuilder()
+            );
         } else if ($action_type === 'SELECT_FEEDBACK') {
             $this->bot->replyText($event->getReplyToken(), Contact::askFeedback());
             $line_user->question->update(['question_number' => LineUsersQuestion::CONTACT]);


### PR DESCRIPTION
## URL

*

## 背景

* 使い方や通知設定、お問い合わせをひとまとめにしたい
* リッチメニューに情報が多くなるのは嫌だったのでその他にした。
* その他の中に情報を入れていく

## todo

- [x] その他を受け取る
- [x] その他の中に「使い方」「通知設定」「お問い合わせ」を入れてアクセスできるようにする

## 影響範囲

* 

## テスト

* 

## 参考資料

* 

## 保留したこと

* 

## その他

* 
